### PR TITLE
fix: duplicated csharp item in non_js_languages section

### DIFF
--- a/state_of_js/js2023/questions.yml
+++ b/state_of_js/js2023/questions.yml
@@ -724,7 +724,6 @@
         - id: clojure
         - id: elm
         - id: julia
-        - id: csharp
         - id: na
 
     - id: ai_tools


### PR DESCRIPTION
`C#` is listed twice in non_js_languages section.