### PR TITLE
Fix urls for dynamic import

### DIFF
--- a/state_of_js/js2021/results/data/features__features_overview.json
+++ b/state_of_js/js2021/results/data/features__features_overview.json
@@ -126,7 +126,7 @@
             "caniuse": null,
             "mdn": {
               "locale": "en-US",
-              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import",
+              "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import",
               "title": "import",
               "summary": "The static import declaration is used to import read-only live bindings which are exported by another module. The imported bindings are called live bindings because they are updated by the module that exported the binding, but cannot be modified by the importing module."
             }

--- a/state_of_js/js2021/results/data/language__dynamic_import.json
+++ b/state_of_js/js2021/results/data/language__dynamic_import.json
@@ -11,7 +11,7 @@
           "caniuse": null,
           "mdn": {
             "locale": "en-US",
-            "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import",
+            "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import",
             "title": "import",
             "summary": "The static import declaration is used to import read-only live bindings which are exported by another module. The imported bindings are called live bindings because they are updated by the module that exported the binding, but cannot be modified by the importing module."
           },

--- a/state_of_js/js2022/results/data/language/dynamic_import.json
+++ b/state_of_js/js2022/results/data/language/dynamic_import.json
@@ -15,7 +15,7 @@
                   "codeHighlighted": "<span class=\"hljs-keyword\">await</span> <span class=\"hljs-keyword\">import</span>(<span class=\"hljs-string\">&#x27;/modules/my-module.js&#x27;</span>)"
                 },
                 "mdn": {
-                  "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import"
+                  "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import"
                 }
               },
               "comments": {

--- a/state_of_js/js2023/results/data/features/reading_list.json
+++ b/state_of_js/js2023/results/data/features/reading_list.json
@@ -114,7 +114,7 @@
                           "codeHighlighted": "<span class=\"hljs-keyword\">await</span> <span class=\"hljs-keyword\">import</span>(<span class=\"hljs-string\">&#x27;/modules/my-module.js&#x27;</span>)"
                         },
                         "mdn": {
-                          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import"
+                          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import"
                         }
                       }
                     },

--- a/state_of_js/js2023/results/data/features/syntax_features.json
+++ b/state_of_js/js2023/results/data/features/syntax_features.json
@@ -49,7 +49,7 @@
                           "codeHighlighted": "<span class=\"hljs-keyword\">await</span> <span class=\"hljs-keyword\">import</span>(<span class=\"hljs-string\">&#x27;/modules/my-module.js&#x27;</span>)"
                         },
                         "mdn": {
-                          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import"
+                          "url": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import"
                         }
                       }
                     },


### PR DESCRIPTION
The urls for [dynamic imports](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/import) are pointing to [static import ](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import)instead. 